### PR TITLE
Fixed numpy FutureWarning

### DIFF
--- a/skgof/vect.py
+++ b/skgof/vect.py
@@ -55,6 +55,6 @@ def varange(starts, count):
                [3, 4, 5, 6, 7]])
     """
     try:
-        return stack(arange(s, s + count) for s in starts)
+        return stack([arange(s, s + count) for s in starts])
     except TypeError:
         return arange(starts, starts + count)


### PR DESCRIPTION
This PR solves the following issue (issue #2):

> import skgof

/usr/local/anaconda3/lib/python3.7/site-packages/skgof/ecdfgof.py:45: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
from .cvmdist import cvm_unif