### PR TITLE
Use six instead of scipy._lib.six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ meta = {
     'packages': ('skgof',),
     'install_requires': (
         'numpy>=1.10',
-        'scipy>=0.16'
+        'scipy>=0.16',
+        'six>=1.0.0'
     ),
     'tests_require': (
         'flake8-print',

--- a/skgof/ecdfgof.py
+++ b/skgof/ecdfgof.py
@@ -38,7 +38,7 @@ from collections import namedtuple
 from functools import partial
 
 from numpy import arange, log, sort
-from scipy._lib.six import string_types
+from six import string_types
 from scipy.stats import distributions
 
 from .addist import ad_unif


### PR DESCRIPTION
Fixes #4 

Newer versions of scipy do not have scipy._lib.six module (probably
because they don't support python 2 anymore). So importing skgof
throws ModuleNotFoundError.
This commit adds an explicit dependency on six and uses that directly
instead of using the scipy._lib.six module.

Another easy way to fix it that does not need extra dependency
would be to drop support for python 2 and just use str instead of
six.string_types.